### PR TITLE
Add filters for tunable parameters

### DIFF
--- a/ktdashboard/ktdashboard.py
+++ b/ktdashboard/ktdashboard.py
@@ -86,12 +86,30 @@ class KTdashboard:
         self.dashboard.sidebar.append(pn.Column(self.yvariable, self.xvariable, self.colorvariable, pn.layout.Divider()))
         self.dashboard.main.append(self.scatter)
 
+        self.multi_choice = list()
+        for tune_param in self.tune_param_keys:
+            values = list(set([d[tune_param] for d in data]))
+            multi_choice = pnw.MultiChoice(name=tune_param, value=values, options=values)
+            self.dashboard.sidebar.append(multi_choice)
+            pn.Row(pn.bind(self.update_data_selection, tune_param, multi_choice))
+
     def __del__(self):
         self.cache_file_handle.close()
 
     def notebook(self):
         """ Return a static version of the dashboard without the template """
         return pn.Row(pn.Column(self.yvariable, self.xvariable, self.colorvariable), self.scatter)
+
+    def update_data_selection(self, tune_param, multi_choice):
+        selection_key = tune_param
+        selection_values = multi_choice
+
+        mask = self.data_df[selection_key].isin(selection_values)
+        index = self.data_df.index[mask].values
+        self.index = index
+
+        data_df = self.data_df[mask]
+        self.source.data = data_df
 
     def update_colors(self, color_by):
         color_mapper = LinearColorMapper(palette='Viridis256', low=min(self.data_df[color_by]),


### PR DESCRIPTION
Looking at a cache file can be daunting when the number of combinations of different tunable parameters is large.

This MR adds multiple choice boxes to the sidebar, one for each tunable parameter, with all the values that occur in the cache.

The plot is automatically updated whenever the selection is changed. For convenience, the indices of the measurements are kept constant.

See the following example:
![image](https://github.com/KernelTuner/dashboard/assets/3500157/01b29dd6-6ab5-45b7-bf57-fde18fb3b6ba)
